### PR TITLE
Allow true object chaining by cloning the emitter object when the config...

### DIFF
--- a/spec/socket.io/emitter_spec.rb
+++ b/spec/socket.io/emitter_spec.rb
@@ -5,33 +5,65 @@ describe SocketIO::Emitter do
   include Timeout
 
   let(:emitter) { SocketIO::Emitter.new(redis: Redis.new(host: "localhost", port: 6380)) }
-  it 'should be able to emit messages to client' do
-    emitter.emit('broadcast event', 'broadcast payload')
 
-    timeout(1) do
-      expect($child_io.gets.chomp).to eq 'broadcast payload'
-    end
-  end
+  describe "integration tests" do
+    it 'should be able to emit messages to client' do
+      emitter.emit('broadcast event', 'broadcast payload')
 
-  it 'should be able to emit messages to namespace' do
-    emitter.of('/nsp').broadcast.emit('broadcast event', 'nsp broadcast payload')
-
-    timeout(1) do
-      expect($child_io.gets.chomp).to eq 'nsp broadcast payload'
-    end
-  end
-
-  it 'should not emit message to all namespace' do
-    emitter.of('/nsp').broadcast.emit('nsp broadcast event', 'nsp broadcast payload')
-
-    timeout(1) do
-      expect($child_io.gets.chomp).to eq 'GOOD'
-    end
-
-    expect {
-      timeout(2) do
-        $child_io.gets
+      timeout(1) do
+        expect($child_io.gets.chomp).to eq 'broadcast payload'
       end
-    }.to raise_error(TimeoutError)
+    end
+
+    it 'should be able to emit messages to namespace' do
+      emitter.of('/nsp').broadcast.emit('broadcast event', 'nsp broadcast payload')
+
+      timeout(1) do
+        expect($child_io.gets.chomp).to eq 'nsp broadcast payload'
+      end
+    end
+
+    it 'should not emit message to all namespace' do
+      emitter.of('/nsp').broadcast.emit('nsp broadcast event', 'nsp broadcast payload')
+
+      timeout(1) do
+        expect($child_io.gets.chomp).to eq 'GOOD'
+      end
+
+      expect {
+        timeout(2) do
+          $child_io.gets
+        end
+      }.to raise_error(TimeoutError)
+    end
+  end
+
+  describe "configuration" do
+    it 'builds a new object each time a new room is added' do
+      single = emitter.in("first")
+      double = single.in("second")
+
+      expect(emitter.instance_variable_get(:@rooms)).to eq []
+      expect(single.instance_variable_get(:@rooms)).to eq ['first']
+      expect(double.instance_variable_get(:@rooms)).to eq ['first', 'second']
+    end
+
+    it 'builds a new object each time the namespace is changed' do
+      first = emitter.of("first")
+      second = first.of("second")
+
+      expect(emitter.instance_variable_get(:@nsp)).to be nil
+      expect(first.instance_variable_get(:@nsp)).to eq "first"
+      expect(second.instance_variable_get(:@nsp)).to eq "second"
+    end
+
+    %i(json volatile broadcast).each do |flag|
+      it "builds a new object each time the #{flag} flag is changed" do
+        flagged = emitter.send(flag)
+
+        expect(emitter.instance_variable_get(:@flags)[flag]).to be nil
+        expect(flagged.instance_variable_get(:@flags)[flag]).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi @nulltask,

This patch will allow users to do things like

    emitter.in("my room").emit("hello").emit("world")

and

    my_room = emitter.in("my room")
    emitter.emit("this goes to everyone")
    my_room.emit("this just goes to my room")

Please let me know if you'd like me to work on it further.

Cheers,
@mogest