### PR TITLE
Added uid to packed message, required by socket.io-emitter

### DIFF
--- a/lib/socket.io/emitter.rb
+++ b/lib/socket.io/emitter.rb
@@ -17,6 +17,8 @@ module SocketIO
       @nsp = nil
       @rooms = []
       @flags = {}
+      # Random UID
+      @uid = ('a'..'z').to_a.shuffle[0,6].join
     end
 
     FLAGS.each do |flag|
@@ -38,7 +40,7 @@ module SocketIO
       packet[:data] = args
       packet[:nsp] = @nsp || '/'
 
-      packed = MessagePack.pack([packet, { rooms: @rooms, flags: @flags }])
+      packed = MessagePack.pack([@uid, packet, { rooms: @rooms, flags: @flags }])
       @redis.publish(@key, packed)
 
       self


### PR DESCRIPTION
Each packed message received by socket.io-emitter needs to have a uid to distinguish rebroadcasting messages from the same node.

However might make sense to use SecureRandom for the ID generation, but this implementation works.